### PR TITLE
Updated requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,11 @@ asgiref==3.2.10
 certifi==2020.6.20
 cffi==1.14.3
 chardet==3.0.4
+crispy-forms-materialize==0.2
 cryptography==3.1.1
 Django==3.0.5
+django-crispy-forms==1.12.0
+django-materializecss-form==1.1.17
 django-pwa==1.0.10
 django-webpush==0.3.3
 http-ece==1.1.0


### PR DESCRIPTION
These 3 pips were not found in requirements.txt which threw error 3 times when I tried to run `python manage.py runserver`.

```
ModuleNotFoundError: No module named 'crispy_forms'
ModuleNotFoundError: No module named 'crispy_forms_materialize'
ModuleNotFoundError: No module named 'materializecssform'
```

So I updated **requirements.txt** with following modules added.

crispy-forms-materialize==0.2
django-crispy-forms==1.12.0
django-materializecss-form==1.1.17